### PR TITLE
Fix alive endpoint filtering

### DIFF
--- a/web/dashboard/views.py
+++ b/web/dashboard/views.py
@@ -48,8 +48,18 @@ def index(request, slug):
     scan_count = scan_histories.count()
     subdomain_count = subdomains.count()
     subdomain_with_ip_count = subdomains.filter(ip_addresses__isnull=False).count()
-    alive_count = subdomains.exclude(http_status__exact=0).count()
-    endpoint_alive_count = endpoints.filter(http_status__exact=200).count()
+    alive_count = (
+        subdomains
+        .filter(http_status__gt=0, http_status__lt=500)
+        .exclude(http_status=404)
+        .count()
+    )
+    endpoint_alive_count = (
+        endpoints
+        .filter(http_status__gt=0, http_status__lt=500)
+        .exclude(http_status=404)
+        .count()
+    )
 
     info_count = vulnerabilities.filter(severity=0).count()
     low_count = vulnerabilities.filter(severity=1).count()

--- a/web/startScan/views.py
+++ b/web/startScan/views.py
@@ -116,7 +116,8 @@ def detail_scan(request, id, slug):
         subdomains
         .values('name')
         .distinct()
-        .filter(http_status__exact=200)
+        .filter(http_status__gt=0, http_status__lt=500)
+        .exclude(http_status=404)
         .count()
     )
     important_count = (
@@ -136,7 +137,8 @@ def detail_scan(request, id, slug):
     )
     endpoint_alive_count = (
         endpoints
-        .filter(http_status__exact=200) # TODO: use is_alive() func as it's more precise
+        .filter(http_status__gt=0, http_status__lt=500)
+        .exclude(http_status=404)
         .values('http_url')
         .distinct()
         .count()
@@ -218,7 +220,11 @@ def detail_scan(request, id, slug):
 def all_subdomains(request, slug):
     subdomains = Subdomain.objects.filter(target_domain__project__slug=slug)
     scan_engines = EngineType.objects.order_by('engine_name').all()
-    alive_subdomains = subdomains.filter(http_status__exact=200) # TODO: replace this with is_alive() function
+    alive_subdomains = (
+        subdomains
+        .filter(http_status__gt=0, http_status__lt=500)
+        .exclude(http_status=404)
+    )
     important_subdomains = (
         subdomains
         .filter(is_important=True)
@@ -1041,7 +1047,8 @@ def create_report(request, id):
         .filter(scan_history__id=id)
         .values('name')
         .distinct()
-        .filter(http_status__exact=200)
+        .filter(http_status__gt=0, http_status__lt=500)
+        .exclude(http_status=404)
         .count()
     )
     interesting_subdomains = get_interesting_subdomains(scan_history=id)

--- a/web/targetApp/views.py
+++ b/web/targetApp/views.py
@@ -400,7 +400,12 @@ def target_summary(request, slug, id):
         .distinct()
     )
     context['subdomain_count'] = subdomains.count()
-    context['alive_count'] = subdomains.filter(http_status__exact=200).count()
+    context['alive_count'] = (
+        subdomains
+        .filter(http_status__gt=0, http_status__lt=500)
+        .exclude(http_status=404)
+        .count()
+    )
 
     # Endpoints
     endpoints = (
@@ -410,7 +415,12 @@ def target_summary(request, slug, id):
         .distinct()
     )
     context['endpoint_count'] = endpoints.count()
-    context['endpoint_alive_count'] = endpoints.filter(http_status__exact=200).count()
+    context['endpoint_alive_count'] = (
+        endpoints
+        .filter(http_status__gt=0, http_status__lt=500)
+        .exclude(http_status=404)
+        .count()
+    )
 
     # Vulnerabilities
     vulnerabilities = Vulnerability.objects.filter(target_domain__id=id)


### PR DESCRIPTION
## Summary
- improve alive endpoint filtering in dashboard, target summary, and scan views
- use HTTP status range logic for subdomain and endpoint counts

## Testing
- `pytest web/startScan/tests.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: 'EntryPoints' object has no attribute 'get')*

------
https://chatgpt.com/codex/tasks/task_e_683f5f0ddc64833196a157fd00e06c95